### PR TITLE
Fix #5

### DIFF
--- a/chronograf-speedtest-dashboard.json
+++ b/chronograf-speedtest-dashboard.json
@@ -20,7 +20,7 @@
 				"name": "Packet Loss",
 				"queries": [
 					{
-						"query": "SELECT mean(\"value\") AS \"mean_value\" FROM \"speedtest\".\"autogen\".\"packet_loss\" WHERE time > :dashboardTime: AND time < :upperDashboardTime: GROUP BY time(15m) FILL(null)",
+						"query": "SELECT mean(\"value\") AS \"mean_value\" FROM \"speedtest\".\"autogen\".\"packet_loss\" WHERE time > :dashboardTime: AND time < :upperDashboardTime: GROUP BY time(15m) FILL(none)",
 						"queryConfig": {
 							"database": "speedtest",
 							"measurement": "packet_loss",
@@ -45,7 +45,7 @@
 								"tags": []
 							},
 							"areTagsAccepted": false,
-							"fill": "null",
+							"fill": "none",
 							"rawText": null,
 							"range": null,
 							"shifts": null
@@ -151,7 +151,7 @@
 				"name": "Latency and Jitter",
 				"queries": [
 					{
-						"query": "SELECT mean(\"value\") AS \"mean_value\" FROM \"speedtest\".\"autogen\".\"jitter\" WHERE time > :dashboardTime: AND time < :upperDashboardTime: GROUP BY time(:interval:) FILL(null)",
+						"query": "SELECT mean(\"value\") AS \"mean_value\" FROM \"speedtest\".\"autogen\".\"jitter\" WHERE time > :dashboardTime: AND time < :upperDashboardTime: GROUP BY time(:interval:) FILL(none)",
 						"queryConfig": {
 							"database": "speedtest",
 							"measurement": "jitter",
@@ -176,7 +176,7 @@
 								"tags": []
 							},
 							"areTagsAccepted": false,
-							"fill": "null",
+							"fill": "none",
 							"rawText": null,
 							"range": null,
 							"shifts": null
@@ -370,7 +370,7 @@
 					"y": {
 						"bounds": [
 							"0",
-							"3"
+							"55"
 						],
 						"label": "upload",
 						"prefix": "",
@@ -508,7 +508,7 @@
 					"y": {
 						"bounds": [
 							"0",
-							"55"
+							"255"
 						],
 						"label": "download",
 						"prefix": "",


### PR DESCRIPTION
![Bildschirmfoto 2021-08-11 um 12 31 24](https://user-images.githubusercontent.com/4415930/129014267-f829d0be-e4a5-4a95-be63-749f207c255e.png)

Value in "Latency and Jitter" and "Package Loss" was often 0 (zero) because the charts were configured with `FILL(null)`, changing this to `FILL(none)` shows the latest value in the chart instead of a zero